### PR TITLE
empty flattenedNodes array when calculating nodes

### DIFF
--- a/src/orbit.js
+++ b/src/orbit.js
@@ -131,6 +131,7 @@ module.exports = function() {
       orbitNodes.ring = orbitSize[0] / 2;
       orbitNodes.depth = 0;
 
+      flattenedNodes = [];
       flattenedNodes.push(orbitNodes);
 
       traverseNestedData(orbitNodes);


### PR DESCRIPTION
Allows nodes of orbits to be set after layout is created using .nodes() and have flattedNodes only account for the newly set nodes.